### PR TITLE
fix: change default cache location

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,10 @@
--   id: prettier
-    name: prettier
-    description: ''
-    entry: prettier --write --ignore-unknown
-    language: node
-    'types': [text]
-    args: []
-    require_serial: false
-    additional_dependencies: ["prettier@3.3.2"]
-    minimum_pre_commit_version: '0'
+- id: prettier
+  name: prettier
+  description: ""
+  entry: prettier --write --ignore-unknown
+  language: node
+  "types": [text]
+  args: [--cache-location, .prettier-cache]
+  require_serial: false
+  additional_dependencies: ["prettier@3.3.2"]
+  minimum_pre_commit_version: "0"


### PR DESCRIPTION
The default location for the prettier cache is within the `node_modules` folder.  Whilst this is typically in a repository `.gitignore` file for projects that use `node` for those that do not this can lead to the accidental commital of unneccessary content (e.g. via `git add .`).

Prettier will delete the cache file if not being executed with `--cache` but only if that `--cache-location` is different to the default.

Ref: https://github.com/prettier/prettier/issues/13032